### PR TITLE
Update GitHub release workflow and ownership rules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for all repository changes.
+* @dam-pav

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: stable-release
@@ -21,7 +21,8 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
+          persist-credentials: false
 
       - name: Bump major version
         id: version
@@ -63,4 +64,5 @@ jobs:
           set -euo pipefail
 
           git tag "v${{ steps.version.outputs.version }}"
+          git remote set-url origin "git@github.com:${{ github.repository }}.git"
           git push --atomic origin HEAD:main HEAD:stable "v${{ steps.version.outputs.version }}"

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "bc-dev-toolset",
   "displayName": "BC Dev Toolset",
   "description": "VS Code command surface for the BC-Dev-Toolset PowerShell toolkit.",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "publisher": "dam-pav",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

- update the stable release workflow to push over SSH with `RELEASE_DEPLOY_KEY`
- add repository CODEOWNERS
- include the automated minor version bump for the `main` PR flow

## Notes

The release workflow now uses the deploy key instead of `GITHUB_TOKEN` for protected branch updates.
