### PR TITLE
fix: enhance backup management with improved file naming conventions and restore parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ That said; you can maintain data persistence in a couple of ways. One is to use 
 
 SQL backup operations create and consume a compatible backup set in each Container configuration's *sqlBackupPath*. Different container configurations can use different folders; set the same folder on multiple Container configurations only when sharing the backup set is intentional. When more than one Container configuration has a non-empty *sqlBackupPath*, container backup and restore operations ask which container to use; container backup also offers an option to back up all qualified containers. Missing or stopped containers are reported and skipped.
 
-Backup files are classified by suffix: *\<name\>.app.bak* for the application database, *\<name\>.tenant.bak* for multitenant tenant databases, or *\<name\>.database.bak* for a single-tenant database. Container backups add the container name to the exported file name to avoid collisions when multiple containers share the same internal database names. Regular BC service SQL Server backups use the database name directly.
+Backup files are classified by suffix: *\<name\>.app.bak* for the application database, *\<tenant-id\>.tenant.bak* for multitenant tenant databases, or *\<name\>.database.bak* for a single-tenant database. Container backups add the container name to the exported file name to avoid collisions when multiple containers share the same names. Tenant backup filenames use tenant IDs because *BcContainerHelper* uses those IDs when restoring the databases; the original SQL database names are needed only to select the source databases during backup.
 
 To retrieve bak files from a SQL Server host you will require credentials with the ability to create remote Powershell sessions to the SQL Server host.
 
@@ -245,13 +245,15 @@ You can follow the naming convention manually and prepare a bak file set manuall
 
 ### Backup
 
-Container backups created by the toolset use this naming convention: *<container\>.<database\>.\*.bak*. The container name in the exported file name identifies the backup's origin. Existing *.bak* files in the selected *sqlBackupPath* are replaced when a new backup set is exported, so file name collisions are not preserved across backup runs.
+Container backups created by the toolset use *<container\>.<database\>.app.bak* for the application database, *<container\>.<tenant-id\>.tenant.bak* for tenant databases, and *<container\>.<database\>.database.bak* for a single-tenant database. The container name in the exported file name identifies the backup's origin. Existing *.bak* files in the selected *sqlBackupPath* are replaced when a new backup set is exported, so file name collisions are not preserved across backup runs.
 
-BC service SQL Server backups use the same role suffixes without adding a container name: *<database\>.app.bak*, *<database\>.tenant.bak*, or *<database\>.database.bak*. They are exported to every distinct *sqlBackupPath* configured on Container configurations.
+BC service SQL Server backups use the same role suffixes without adding a container name: *<database\>.app.bak*, *<tenant-id\>.tenant.bak*, or *<database\>.database.bak*. They are exported to every distinct *sqlBackupPath* configured on Container configurations.
+
+> Warning: ALL pre-existing *.bak* files in the target folder will be removed during backup.
 
 ### Restore
 
-Restore is based on the selected folder's content. It looks for \*.app.bak, \*.tenant.bak, and \*.database.bak files and does not require file names to start with the target container name. You can copy a compatible backup set into the target configuration's *sqlBackupPath* and restore it from there.
+Restore is based on the selected folder's content. It looks for \*.app.bak, \*.tenant.bak, and \*.database.bak files and does not require file names to start with the target container name. For a container-exported multitenant set, the shared source-container prefix is removed when the files are staged under the names expected by *BcContainerHelper*. You can copy a compatible backup set into the target configuration's *sqlBackupPath* and restore it from there.
 
 ## Testing
 

--- a/common/BackupMgt.ps1
+++ b/common/BackupMgt.ps1
@@ -85,45 +85,125 @@ function Get-SqlBackupSetEntries {
         [string] $backupRootPath
     )
 
+    $backupFiles = @(Get-ChildItem -Path $backupRootPath -Filter "*.bak" -File -ErrorAction SilentlyContinue)
+    $classifiedFiles = @($backupFiles | ForEach-Object {
+        if ($_.Name -match '^(?<databaseName>.+)\.(?<databaseRole>app|tenant|database)\.bak$') {
+            [PSCustomObject]@{
+                File = $_
+                ExportedDatabaseName = $Matches.databaseName
+                DatabaseRole = $Matches.databaseRole
+            }
+        }
+        else {
+            Write-Host "Ignoring backup file '$($_.Name)' because it does not follow the '<container>.<database>.app.bak', '<container>.<database>.tenant.bak', or '<container>.<database>.database.bak' naming convention." -ForegroundColor Yellow
+        }
+    })
+
+    $containerPrefix = Get-SqlBackupSetContainerPrefix -classifiedFiles $classifiedFiles
     $entries = @()
-    foreach ($backupFile in @(Get-ChildItem -Path $backupRootPath -Filter "*.bak" -File -ErrorAction SilentlyContinue)) {
-        if ($backupFile.Name -match '^(?<databaseName>.+)\.app\.bak$') {
+    foreach ($classifiedFile in $classifiedFiles) {
+        $backupFile = $classifiedFile.File
+        $databaseName = $classifiedFile.ExportedDatabaseName
+        if (-not [string]::IsNullOrEmpty($containerPrefix)) {
+            $databaseName = $databaseName.Substring($containerPrefix.Length)
+        }
+
+        if ($classifiedFile.DatabaseRole -eq "app") {
             $entries += [PSCustomObject]@{
                 SourcePath = $backupFile.FullName
                 SourceFileName = $backupFile.Name
-                DatabaseName = $Matches.databaseName
+                DatabaseName = $databaseName
                 DatabaseRole = "app"
                 HelperFileName = "app.bak"
             }
             continue
         }
 
-        if ($backupFile.Name -match '^(?<databaseName>.+)\.tenant\.bak$') {
+        if ($classifiedFile.DatabaseRole -eq "tenant") {
             $entries += [PSCustomObject]@{
                 SourcePath = $backupFile.FullName
                 SourceFileName = $backupFile.Name
-                DatabaseName = $Matches.databaseName
+                DatabaseName = $databaseName
                 DatabaseRole = "tenant"
-                HelperFileName = "$($Matches.databaseName).bak"
+                HelperFileName = "$databaseName.bak"
             }
             continue
         }
 
-        if ($backupFile.Name -match '^(?<databaseName>.+)\.database\.bak$') {
+        if ($classifiedFile.DatabaseRole -eq "database") {
             $entries += [PSCustomObject]@{
                 SourcePath = $backupFile.FullName
                 SourceFileName = $backupFile.Name
-                DatabaseName = $Matches.databaseName
+                DatabaseName = $databaseName
                 DatabaseRole = "database"
                 HelperFileName = "database.bak"
             }
-            continue
         }
-
-        Write-Host "Ignoring backup file '$($backupFile.Name)' because it does not follow the '<container>.<database>.app.bak', '<container>.<database>.tenant.bak', or '<container>.<database>.database.bak' naming convention." -ForegroundColor Yellow
     }
 
     return $entries
+}
+
+function Get-SqlBackupSetContainerPrefix {
+    Param (
+        [Parameter(Mandatory=$true)]
+        [AllowEmptyCollection()]
+        [array] $classifiedFiles
+    )
+
+    # Container exports contain an application (or single-tenant) backup and prefix every
+    # database name with the same container name. Service backups do not share that prefix.
+    $hasPrimaryDatabase = ($classifiedFiles.DatabaseRole -contains "app") -or ($classifiedFiles.DatabaseRole -contains "database")
+    if ($classifiedFiles.Count -lt 2 -or -not $hasPrimaryDatabase) {
+        return ""
+    }
+
+    $firstName = [string]$classifiedFiles[0].ExportedDatabaseName
+    $containerPrefix = ""
+    for ($index = 0; $index -lt $firstName.Length; $index++) {
+        if ($firstName[$index] -ne '.') {
+            continue
+        }
+
+        $candidatePrefix = $firstName.Substring(0, $index + 1)
+        $allNamesMatch = @($classifiedFiles | Where-Object {
+            $exportedName = [string]$_.ExportedDatabaseName
+            $exportedName.Length -le $candidatePrefix.Length -or
+                -not $exportedName.StartsWith($candidatePrefix, [System.StringComparison]::OrdinalIgnoreCase)
+        }).Count -eq 0
+        if ($allNamesMatch) {
+            $containerPrefix = $candidatePrefix
+        }
+    }
+
+    return $containerPrefix
+}
+
+function Get-BcContainerSqlBackupRestoreParameters {
+    Param (
+        [Parameter(Mandatory=$true)]
+        [string] $containerName,
+        [Parameter(Mandatory=$true)]
+        [string] $bakFolder,
+        [Parameter(Mandatory=$true)]
+        [AllowEmptyCollection()]
+        [array] $backupEntries
+    )
+
+    $restoreParameters = @{
+        containerName = $containerName
+        bakFolder = $bakFolder
+    }
+    $tenantIds = @($backupEntries |
+        Where-Object { $_.DatabaseRole -eq "tenant" } |
+        Select-Object -ExpandProperty DatabaseName -Unique)
+    if ($tenantIds.Count -gt 0) {
+        # Supplying tenant IDs avoids BcContainerHelper querying the BC service before
+        # the restore. This allows retries when an earlier failed restore left it stopped.
+        $restoreParameters.tenant = $tenantIds
+    }
+
+    return $restoreParameters
 }
 
 function Get-BcContainerDatabaseBackupMap {
@@ -147,7 +227,7 @@ function Get-BcContainerDatabaseBackupMap {
             $map += @(Get-NAVTenant -ServerInstance BC | ForEach-Object {
                 [PSCustomObject]@{
                     HelperFileName = "$($_.Id).bak"
-                    ExportFileName = "$($_.DatabaseName).tenant.bak"
+                    ExportFileName = "$($_.Id).tenant.bak"
                 }
             })
 
@@ -403,9 +483,11 @@ function Restore-BcContainerSqlBackupSet {
             continue
         }
 
-        Restore-DatabasesInBcContainer `
+        $restoreParameters = Get-BcContainerSqlBackupRestoreParameters `
             -containerName $configuration.container `
-            -bakFolder $sharedRestorePath
+            -bakFolder $sharedRestorePath `
+            -backupEntries $backupEntries
+        Restore-DatabasesInBcContainer @restoreParameters
 
         Write-Host "SQL backup set restored to container '$($configuration.container)'." -ForegroundColor Green
     }
@@ -796,6 +878,40 @@ function Backup-RemoteSqlDatabases {
     }
 }
 
+function Get-BcServiceSqlBackupRequests {
+    Param (
+        [Parameter(Mandatory=$true)]
+        [PSObject] $serviceDatabaseInfo,
+        [Parameter(Mandatory=$true)]
+        [string] $serverInstance
+    )
+
+    if (-not $serviceDatabaseInfo.Multitenant) {
+        return @([PSCustomObject]@{
+            DatabaseName = $serviceDatabaseInfo.DatabaseName
+            FileName = (Get-SqlBackupFileName -databaseName $serviceDatabaseInfo.DatabaseName -databaseRole "database")
+        })
+    }
+
+    $backupRequests = @([PSCustomObject]@{
+        DatabaseName = $serviceDatabaseInfo.DatabaseName
+        FileName = (Get-SqlBackupFileName -databaseName $serviceDatabaseInfo.DatabaseName -databaseRole "app")
+    })
+    $tenants = @($serviceDatabaseInfo.Tenants)
+    if ($tenants.Count -eq 0) {
+        throw "No tenants found for multitenant service instance '$serverInstance'."
+    }
+
+    foreach ($tenant in $tenants) {
+        $backupRequests += [PSCustomObject]@{
+            DatabaseName = $tenant.DatabaseName
+            FileName = (Get-SqlBackupFileName -databaseName $tenant.Id -databaseRole "tenant")
+        }
+    }
+
+    return $backupRequests
+}
+
 function Export-BcServiceSqlBackupSet {
     Param (
         [Parameter(Mandatory=$true)]
@@ -840,7 +956,6 @@ function Export-BcServiceSqlBackupSet {
         $databaseServer = $serviceDatabaseInfo.DatabaseServer
         $databaseInstance = $serviceDatabaseInfo.DatabaseInstance
         $databaseName = $serviceDatabaseInfo.DatabaseName
-        $multitenant = $serviceDatabaseInfo.Multitenant
 
         if ([string]::IsNullOrWhiteSpace($databaseServer)) {
             $databaseServer = "localhost"
@@ -856,31 +971,9 @@ function Export-BcServiceSqlBackupSet {
             $sqlCredential = New-Object pscredential $configuration.databaseUser, $securePassword
         }
 
-        $backupRequests = @()
-
-        if ($multitenant) {
-            $backupRequests += [PSCustomObject]@{
-                DatabaseName = $databaseName
-                FileName = (Get-SqlBackupFileName -databaseName $databaseName -databaseRole "app")
-            }
-
-            $tenants = @($serviceDatabaseInfo.Tenants)
-            if ($tenants.Count -eq 0) {
-                throw "No tenants found for multitenant service instance '$serverInstance'."
-            }
-
-            foreach ($tenant in $tenants) {
-                $backupRequests += [PSCustomObject]@{
-                    DatabaseName = $tenant.DatabaseName
-                    FileName = (Get-SqlBackupFileName -databaseName $tenant.DatabaseName -databaseRole "tenant")
-                }
-            }
-        } else {
-            $backupRequests += [PSCustomObject]@{
-                DatabaseName = $databaseName
-                FileName = (Get-SqlBackupFileName -databaseName $databaseName -databaseRole "database")
-            }
-        }
+        $backupRequests = @(Get-BcServiceSqlBackupRequests `
+            -serviceDatabaseInfo $serviceDatabaseInfo `
+            -serverInstance $serverInstance)
 
         foreach ($exportRootPath in $exportRootPaths) {
             New-Item -ItemType Directory -Path $exportRootPath -Force | Out-Null

--- a/common/TestMgt.ps1
+++ b/common/TestMgt.ps1
@@ -163,9 +163,11 @@ function Restore-TestContainerBackupIfExists {
     Write-Host ""
     Write-Host "Restoring SQL backup set to container '$($configuration.container)'." -ForegroundColor Green
     Write-Host "Backup folder: $backupRootPath" -ForegroundColor Gray
-    Restore-DatabasesInBcContainer `
+    $restoreParameters = Get-BcContainerSqlBackupRestoreParameters `
         -containerName $configuration.container `
-        -bakFolder $sharedRestorePath
+        -bakFolder $sharedRestorePath `
+        -backupEntries $backupEntries
+    Restore-DatabasesInBcContainer @restoreParameters
 
     Write-Host "SQL backup set restored to container '$($configuration.container)'." -ForegroundColor Green
 }

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "bc-dev-toolset",
   "displayName": "Business Central Developer's Toolset",
   "description": "Manage your Business Central development environment. Containers, backups, workspaces and more.",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "publisher": "dam-pav",
   "icon": "assets/bc-dev-toolset.logo.png",
   "license": "MIT",

--- a/vscode-extension/test/backup-mgt.test.js
+++ b/vscode-extension/test/backup-mgt.test.js
@@ -1,0 +1,101 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const test = require('node:test');
+
+const backupMgtPath = path.resolve(__dirname, '..', '..', 'common', 'BackupMgt.ps1');
+
+function quotePowerShell(value) {
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+function getBackupEntries(fileNames) {
+  const backupFolder = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-dev-toolset-backup-test-'));
+  try {
+    for (const fileName of fileNames) {
+      fs.writeFileSync(path.join(backupFolder, fileName), '');
+    }
+
+    const script = [
+      `. ${quotePowerShell(backupMgtPath)}`,
+      `@(Get-SqlBackupSetEntries -backupRootPath ${quotePowerShell(backupFolder)}) | ConvertTo-Json -Compress`
+    ].join('; ');
+    const result = spawnSync('pwsh', ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', script], {
+      encoding: 'utf8'
+    });
+    assert.equal(result.status, 0, result.stderr);
+    return JSON.parse(result.stdout);
+  } finally {
+    fs.rmSync(backupFolder, { recursive: true, force: true });
+  }
+}
+
+test('removes a shared container prefix when staging a multitenant backup set', () => {
+  const entries = getBackupEntries([
+    'OTPtest.CRONUS.app.bak',
+    'OTPtest.default.tenant.bak',
+    'OTPtest.tenant.tenant.bak'
+  ]);
+
+  assert.deepEqual(entries.map(({ DatabaseName, HelperFileName }) => ({ DatabaseName, HelperFileName }))
+    .sort((left, right) => left.HelperFileName.localeCompare(right.HelperFileName)), [
+    { DatabaseName: 'CRONUS', HelperFileName: 'app.bak' },
+    { DatabaseName: 'default', HelperFileName: 'default.bak' },
+    { DatabaseName: 'tenant', HelperFileName: 'tenant.bak' }
+  ]);
+});
+
+test('preserves database names in a service-created backup set', () => {
+  const entries = getBackupEntries([
+    'CRONUS.app.bak',
+    'default.tenant.bak',
+    'tenant.tenant.bak'
+  ]);
+
+  assert.deepEqual(entries.map(({ DatabaseName, HelperFileName }) => ({ DatabaseName, HelperFileName }))
+    .sort((left, right) => left.HelperFileName.localeCompare(right.HelperFileName)), [
+    { DatabaseName: 'CRONUS', HelperFileName: 'app.bak' },
+    { DatabaseName: 'default', HelperFileName: 'default.bak' },
+    { DatabaseName: 'tenant', HelperFileName: 'tenant.bak' }
+  ]);
+});
+
+test('passes tenant IDs to BcContainerHelper so a stopped service can be restored', () => {
+  const script = [
+    `. ${quotePowerShell(backupMgtPath)}`,
+    "$entries = @([pscustomobject]@{ DatabaseName='default'; DatabaseRole='tenant' }, [pscustomobject]@{ DatabaseName='tenant'; DatabaseRole='tenant' })",
+    "Get-BcContainerSqlBackupRestoreParameters -containerName 'OTPtest' -bakFolder 'C:\\restore' -backupEntries $entries | ConvertTo-Json -Compress"
+  ].join('; ');
+  const result = spawnSync('pwsh', ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', script], {
+    encoding: 'utf8'
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    bakFolder: 'C:\\restore',
+    containerName: 'OTPtest',
+    tenant: ['default', 'tenant']
+  });
+});
+
+test('uses tenant IDs for service backup filenames while retaining source database names', () => {
+  const script = [
+    `. ${quotePowerShell(backupMgtPath)}`,
+    "$info = [pscustomobject]@{ DatabaseName='BC App'; Multitenant=$true; Tenants=@([pscustomobject]@{ Id='north'; DatabaseName='BC Tenant North' }, [pscustomobject]@{ Id='south'; DatabaseName='BC Tenant South' }) }",
+    "@(Get-BcServiceSqlBackupRequests -serviceDatabaseInfo $info -serverInstance 'BC') | ConvertTo-Json -Compress"
+  ].join('; ');
+  const result = spawnSync('pwsh', ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', script], {
+    encoding: 'utf8'
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), [
+    { DatabaseName: 'BC App', FileName: 'BC App.app.bak' },
+    { DatabaseName: 'BC Tenant North', FileName: 'north.tenant.bak' },
+    { DatabaseName: 'BC Tenant South', FileName: 'south.tenant.bak' }
+  ]);
+});


### PR DESCRIPTION
- filename prefixes are now based on tenant ids, not database names
- repeat restore operation now recovers from previous failure that left bc service inactive