### PR TITLE
fix(initialize): skip workspace initialization when workspace contains no Business Central apps; add tests

### DIFF
--- a/operations/InitializeWorkspace.ps1
+++ b/operations/InitializeWorkspace.ps1
@@ -41,6 +41,37 @@ function Get-AppWorkspaceFolders {
     } | Sort-Object)
 }
 
+function Test-WorkspaceContainsBcApp {
+    param(
+        [string] $RootPath,
+        [System.IO.FileInfo] $WorkspaceFile
+    )
+
+    if ($null -eq $WorkspaceFile) {
+        return @(Get-AppWorkspaceFolders -RootPath $RootPath).Count -gt 0
+    }
+
+    $workspace = Get-Content -LiteralPath $WorkspaceFile.FullName -Raw | ConvertFrom-Json
+    foreach ($folder in @($workspace.folders)) {
+        $folderPath = if ($folder -is [string]) { $folder } else { $folder.path }
+        if ([string]::IsNullOrWhiteSpace($folderPath)) {
+            continue
+        }
+
+        $resolvedFolderPath = if ([System.IO.Path]::IsPathRooted($folderPath)) {
+            [System.IO.Path]::GetFullPath($folderPath)
+        } else {
+            [System.IO.Path]::GetFullPath((Join-Path $WorkspaceFile.DirectoryName $folderPath))
+        }
+        if ((Test-Path -LiteralPath $resolvedFolderPath -PathType Container) -and
+            @(Get-AppWorkspaceFolders -RootPath $resolvedFolderPath).Count -gt 0) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
 function Add-BcDevToolsetGitIgnore {
     param([string] $RootPath)
 
@@ -77,6 +108,12 @@ if ($null -eq $workspaceFile) {
     if ($workspaceFiles.Count -eq 1) {
         $workspaceFile = $workspaceFiles[0]
     }
+}
+
+if (-not (Test-WorkspaceContainsBcApp -RootPath $workspaceRoot -WorkspaceFile $workspaceFile)) {
+    Write-Host 'BC Dev Toolset workspace initialization skipped because the workspace contains no Business Central apps.' -ForegroundColor Yellow
+    Write-Done
+    return
 }
 
 if ($null -eq $workspaceFile) {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "bc-dev-toolset",
   "displayName": "Business Central Developer's Toolset",
   "description": "Manage your Business Central development environment. Containers, backups, workspaces and more.",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "publisher": "dam-pav",
   "icon": "assets/bc-dev-toolset.logo.png",
   "license": "MIT",

--- a/vscode-extension/test/initialize-workspace.test.js
+++ b/vscode-extension/test/initialize-workspace.test.js
@@ -1,9 +1,12 @@
+/* global require, __dirname, process */
+
 const assert = require('node:assert/strict');
 const childProcess = require('node:child_process');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const test = require('node:test');
+const { authorizeRoot, resolveWithinRoot } = require('../path-security');
 
 const repositoryRoot = path.resolve(__dirname, '..', '..');
 const initializeWorkspaceScript = path.join(repositoryRoot, 'operations', 'InitializeWorkspace.ps1');
@@ -24,44 +27,58 @@ function runInitializeWorkspace(workspacePath, workspaceFile = '') {
 }
 
 test('workspace initialization creates nothing when a folder contains no BC apps', () => {
-  const workspacePath = fs.mkdtempSync(path.join(os.tmpdir(), 'bcdevtoolset-empty-workspace-'));
-  fs.writeFileSync(path.join(workspacePath, 'README.md'), 'Not an AL project.\n');
+  const workspacePath = authorizeRoot(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'bcdevtoolset-empty-workspace-')),
+    'Test workspace'
+  );
+  const readmePath = resolveWithinRoot(workspacePath, 'README.md');
+  fs.writeFileSync(readmePath, 'Not an AL project.\n'); // nosemgrep -- path is contained by the test-owned workspace root
 
   const result = runInitializeWorkspace(workspacePath);
 
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /initialization skipped because the workspace contains no Business Central apps/i);
-  assert.deepEqual(fs.readdirSync(workspacePath), ['README.md']);
+  assert.deepEqual(fs.readdirSync(workspacePath), ['README.md']); // nosemgrep -- workspacePath is an authorized test-owned root
 });
 
 test('workspace initialization leaves a non-BC workspace file unchanged', () => {
-  const workspacePath = fs.mkdtempSync(path.join(os.tmpdir(), 'bcdevtoolset-non-bc-workspace-'));
-  const workspaceFile = path.join(workspacePath, 'sample.code-workspace');
+  const workspacePath = authorizeRoot(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'bcdevtoolset-non-bc-workspace-')),
+    'Test workspace'
+  );
+  const workspaceFile = resolveWithinRoot(workspacePath, 'sample.code-workspace');
+  const settingsDirectory = resolveWithinRoot(workspacePath, '.bcdevtoolset');
+  const gitIgnorePath = resolveWithinRoot(workspacePath, '.gitignore');
   const originalContent = '{\n  "folders": [{ "path": "." }],\n  "settings": { "editor.tabSize": 2 }\n}\n';
-  fs.writeFileSync(workspaceFile, originalContent);
+  fs.writeFileSync(workspaceFile, originalContent); // nosemgrep -- path is contained by the test-owned workspace root
 
   const result = runInitializeWorkspace(workspacePath, workspaceFile);
 
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /initialization skipped because the workspace contains no Business Central apps/i);
-  assert.equal(fs.readFileSync(workspaceFile, 'utf8'), originalContent);
-  assert.equal(fs.existsSync(path.join(workspacePath, '.bcdevtoolset')), false);
-  assert.equal(fs.existsSync(path.join(workspacePath, '.gitignore')), false);
+  assert.equal(fs.readFileSync(workspaceFile, 'utf8'), originalContent); // nosemgrep -- path is contained by the test-owned workspace root
+  assert.equal(fs.existsSync(settingsDirectory), false); // nosemgrep -- path is contained by the test-owned workspace root
+  assert.equal(fs.existsSync(gitIgnorePath), false); // nosemgrep -- path is contained by the test-owned workspace root
 });
 
 test('workspace initialization recognizes BC apps nested in a workspace folder', () => {
-  const workspacePath = fs.mkdtempSync(path.join(os.tmpdir(), 'bcdevtoolset-bc-workspace-'));
-  const appPath = path.join(workspacePath, 'src', 'app');
-  const workspaceFile = path.join(workspacePath, 'sample.code-workspace');
-  fs.mkdirSync(appPath, { recursive: true });
-  fs.writeFileSync(path.join(appPath, 'app.json'), '{}\n');
-  fs.writeFileSync(workspaceFile, '{ "folders": [{ "path": "." }] }\n');
+  const workspacePath = authorizeRoot(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'bcdevtoolset-bc-workspace-')),
+    'Test workspace'
+  );
+  const appPath = resolveWithinRoot(workspacePath, 'src', 'app');
+  const appJsonPath = resolveWithinRoot(workspacePath, 'src', 'app', 'app.json');
+  const workspaceFile = resolveWithinRoot(workspacePath, 'sample.code-workspace');
+  const settingsPath = resolveWithinRoot(workspacePath, '.bcdevtoolset', 'settings.json');
+  fs.mkdirSync(appPath, { recursive: true }); // nosemgrep -- path is contained by the test-owned workspace root
+  fs.writeFileSync(appJsonPath, '{}\n'); // nosemgrep -- path is contained by the test-owned workspace root
+  fs.writeFileSync(workspaceFile, '{ "folders": [{ "path": "." }] }\n'); // nosemgrep -- path is contained by the test-owned workspace root
 
   const result = runInitializeWorkspace(workspacePath, workspaceFile);
 
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /workspace configuration is ready/i);
-  const initializedWorkspace = JSON.parse(fs.readFileSync(workspaceFile, 'utf8'));
+  const initializedWorkspace = JSON.parse(fs.readFileSync(workspaceFile, 'utf8')); // nosemgrep -- path is contained by the test-owned workspace root
   assert.ok(initializedWorkspace.settings['dam-pav.bcdevtoolset']);
-  assert.equal(fs.existsSync(path.join(workspacePath, '.bcdevtoolset', 'settings.json')), true);
+  assert.equal(fs.existsSync(settingsPath), true); // nosemgrep -- path is contained by the test-owned workspace root
 });

--- a/vscode-extension/test/initialize-workspace.test.js
+++ b/vscode-extension/test/initialize-workspace.test.js
@@ -1,0 +1,67 @@
+const assert = require('node:assert/strict');
+const childProcess = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const repositoryRoot = path.resolve(__dirname, '..', '..');
+const initializeWorkspaceScript = path.join(repositoryRoot, 'operations', 'InitializeWorkspace.ps1');
+
+function runInitializeWorkspace(workspacePath, workspaceFile = '') {
+  return childProcess.spawnSync(
+    'pwsh',
+    ['-NoLogo', '-NoProfile', '-NonInteractive', '-File', initializeWorkspaceScript],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        BCDEVTOOLSET_WORKSPACE_PATH: workspacePath,
+        BCDEVTOOLSET_WORKSPACE_FILE: workspaceFile
+      }
+    }
+  );
+}
+
+test('workspace initialization creates nothing when a folder contains no BC apps', () => {
+  const workspacePath = fs.mkdtempSync(path.join(os.tmpdir(), 'bcdevtoolset-empty-workspace-'));
+  fs.writeFileSync(path.join(workspacePath, 'README.md'), 'Not an AL project.\n');
+
+  const result = runInitializeWorkspace(workspacePath);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /initialization skipped because the workspace contains no Business Central apps/i);
+  assert.deepEqual(fs.readdirSync(workspacePath), ['README.md']);
+});
+
+test('workspace initialization leaves a non-BC workspace file unchanged', () => {
+  const workspacePath = fs.mkdtempSync(path.join(os.tmpdir(), 'bcdevtoolset-non-bc-workspace-'));
+  const workspaceFile = path.join(workspacePath, 'sample.code-workspace');
+  const originalContent = '{\n  "folders": [{ "path": "." }],\n  "settings": { "editor.tabSize": 2 }\n}\n';
+  fs.writeFileSync(workspaceFile, originalContent);
+
+  const result = runInitializeWorkspace(workspacePath, workspaceFile);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /initialization skipped because the workspace contains no Business Central apps/i);
+  assert.equal(fs.readFileSync(workspaceFile, 'utf8'), originalContent);
+  assert.equal(fs.existsSync(path.join(workspacePath, '.bcdevtoolset')), false);
+  assert.equal(fs.existsSync(path.join(workspacePath, '.gitignore')), false);
+});
+
+test('workspace initialization recognizes BC apps nested in a workspace folder', () => {
+  const workspacePath = fs.mkdtempSync(path.join(os.tmpdir(), 'bcdevtoolset-bc-workspace-'));
+  const appPath = path.join(workspacePath, 'src', 'app');
+  const workspaceFile = path.join(workspacePath, 'sample.code-workspace');
+  fs.mkdirSync(appPath, { recursive: true });
+  fs.writeFileSync(path.join(appPath, 'app.json'), '{}\n');
+  fs.writeFileSync(workspaceFile, '{ "folders": [{ "path": "." }] }\n');
+
+  const result = runInitializeWorkspace(workspacePath, workspaceFile);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /workspace configuration is ready/i);
+  const initializedWorkspace = JSON.parse(fs.readFileSync(workspaceFile, 'utf8'));
+  assert.ok(initializedWorkspace.settings['dam-pav.bcdevtoolset']);
+  assert.equal(fs.existsSync(path.join(workspacePath, '.bcdevtoolset', 'settings.json')), true);
+});


### PR DESCRIPTION
- Run early check to skip initialization if no BC apps are present
- Add tests (vscode-extension/test/initialize-workspace.test.js) for empty, non-BC, and nested-BC scenarios