### PR TITLE
feat(backup): support direct bakFile restore for stopped single-tenant services

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ The Tests group contains two operations:
 - *Run AL test tool tests* runs Business Central AL test tool tests with *Run-TestsInBcContainer*.
 - *Run page script tests* runs page scripting recordings from *recordingsPath* and writes results to *pageScriptTestResultsPath*.
 
-Both operations execute against a Container configuration with *includeTestToolkit* set to `true`, regardless of its *targetType*. If only one eligible Container configuration exists and *executeTestsInContainerName* is empty, tests run in that container as-is: no backup restore and no app deployment are performed.
+Both operations run in a Docker container selected from configurations whose *serverType* is `Container`, whose *includeTestToolkit* value is `true`, and whose *container* value is not empty. The configuration's *targetType* can be `Dev`, `Test`, or `Production`; it does not affect eligibility. If only one eligible Container configuration exists and *executeTestsInContainerName* is empty, tests run in that container as-is: no backup restore and no app deployment are performed.
 
 If *executeTestsInContainerName* is set, or if multiple eligible Container configurations are available, the operation resolves the configured container name or asks which configured container to use. It then asks for explicit confirmation before running tests in that container.
 
@@ -301,12 +301,10 @@ to remove the files from git. You will need to commit these changes. Beware, thi
       "path": "Project/App"
     },
 	{
-      "path": "BC-Dev-Toolset"
+      "path": "Project/Test-App"
     }
   ],
   "settings": {
-    "liveServer.settings.multiRootWorkspaceName": "BC-Dev-Toolset",
-    "powershell.cwd": "BC-Dev-Toolset",
     "al.symbolsCountryRegion": "w1",
     "dam-pav.bcdevtoolset": {
       "selectArtifact": "Latest",
@@ -339,9 +337,9 @@ to remove the files from git. You will need to commit these changes. Beware, thi
         },
         {
           "name": "Test environment",
-                  "serverType": "Cloud",
-                  "environmentName": "TEST",
-                  "tenant": "tenants-guid-comes-here"
+          "serverType": "Cloud",
+          "environmentName": "TEST",
+          "tenant": "tenants-guid-comes-here"
         }
       ]
     }
@@ -368,7 +366,7 @@ These are VS Code extension settings. They belong to the developer's VS Code set
 - `bcDevToolset.toolsetPath`: Overrides the central BC-Dev-Toolset runtime location.
 - `bcDevToolset.powershellExecutable`: PowerShell executable used to run operations.
 - `bcDevToolset.localSettingsPath`: Workspace-relative path to the local settings file.
-- `bcDevToolset.shortcuts`: Decide where you want Docker to place shortcuts for the new containers it creates. Can be *None*, *Desktop* or *StartMenu*. While Docker's default is *Desktop*, the toolsets's default is *None*.
+- `bcDevToolset.shortcuts`: Controls where BcContainerHelper places shortcuts for newly created containers. Can be *None*, *Desktop* or *StartMenu*. While BcContainerHelper's default is *Desktop*, BC Dev Toolset's default is *None*.
 - `bcDevToolset.hostHelperFolder`: Overrides default BcContainerHelper host helper folder used by runtime operations.
 
 ### Workspace settings

--- a/common/BackupMgt.ps1
+++ b/common/BackupMgt.ps1
@@ -192,8 +192,17 @@ function Get-BcContainerSqlBackupRestoreParameters {
 
     $restoreParameters = @{
         containerName = $containerName
-        bakFolder = $bakFolder
     }
+    $databaseEntries = @($backupEntries | Where-Object { $_.DatabaseRole -eq "database" })
+    if ($databaseEntries.Count -eq 1 -and $backupEntries.Count -eq 1) {
+        # The bakFile path avoids BcContainerHelper calling Set-NavServerInstance -Stop
+        # unconditionally. That command fails when a previous restore left the service stopped.
+        $restoreParameters.bakFile = Join-Path $bakFolder $databaseEntries[0].HelperFileName
+        $restoreParameters.databaseName = $databaseEntries[0].DatabaseName
+        return $restoreParameters
+    }
+
+    $restoreParameters.bakFolder = $bakFolder
     $tenantIds = @($backupEntries |
         Where-Object { $_.DatabaseRole -eq "tenant" } |
         Select-Object -ExpandProperty DatabaseName -Unique)
@@ -204,6 +213,43 @@ function Get-BcContainerSqlBackupRestoreParameters {
     }
 
     return $restoreParameters
+}
+
+function Restore-BcContainerSqlBackupEntries {
+    Param (
+        [Parameter(Mandatory=$true)]
+        [string] $containerName,
+        [Parameter(Mandatory=$true)]
+        [string] $bakFolder,
+        [Parameter(Mandatory=$true)]
+        [AllowEmptyCollection()]
+        [array] $backupEntries
+    )
+
+    $restoreParameters = Get-BcContainerSqlBackupRestoreParameters `
+        -containerName $containerName `
+        -bakFolder $bakFolder `
+        -backupEntries $backupEntries
+
+    if ($restoreParameters.ContainsKey("bakFile")) {
+        $restoreParameters.databaseName = Invoke-ScriptInBcContainer -containerName $containerName -ScriptBlock {
+            $customConfigFile = Join-Path (Get-Item "C:\Program Files\Microsoft Dynamics NAV\*\Service").FullName "CustomSettings.config"
+            [xml]$customConfig = [System.IO.File]::ReadAllText($customConfigFile)
+            $server = Get-NAVServerInstance -ServerInstance BC
+            if ($server.State -ne "Stopped") {
+                Set-NAVServerInstance -ServerInstance BC -Stop | Out-Null
+            }
+            return $customConfig.SelectSingleNode("//appSettings/add[@key='DatabaseName']").Value
+        }
+    }
+
+    Restore-DatabasesInBcContainer @restoreParameters
+
+    if ($restoreParameters.ContainsKey("bakFile")) {
+        Invoke-ScriptInBcContainer -containerName $containerName -ScriptBlock {
+            Set-NAVServerInstance -ServerInstance BC -Start
+        }
+    }
 }
 
 function Get-BcContainerDatabaseBackupMap {
@@ -483,11 +529,10 @@ function Restore-BcContainerSqlBackupSet {
             continue
         }
 
-        $restoreParameters = Get-BcContainerSqlBackupRestoreParameters `
+        Restore-BcContainerSqlBackupEntries `
             -containerName $configuration.container `
             -bakFolder $sharedRestorePath `
             -backupEntries $backupEntries
-        Restore-DatabasesInBcContainer @restoreParameters
 
         Write-Host "SQL backup set restored to container '$($configuration.container)'." -ForegroundColor Green
     }

--- a/common/TestMgt.ps1
+++ b/common/TestMgt.ps1
@@ -163,11 +163,10 @@ function Restore-TestContainerBackupIfExists {
     Write-Host ""
     Write-Host "Restoring SQL backup set to container '$($configuration.container)'." -ForegroundColor Green
     Write-Host "Backup folder: $backupRootPath" -ForegroundColor Gray
-    $restoreParameters = Get-BcContainerSqlBackupRestoreParameters `
+    Restore-BcContainerSqlBackupEntries `
         -containerName $configuration.container `
         -bakFolder $sharedRestorePath `
         -backupEntries $backupEntries
-    Restore-DatabasesInBcContainer @restoreParameters
 
     Write-Host "SQL backup set restored to container '$($configuration.container)'." -ForegroundColor Green
 }

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "bc-dev-toolset",
   "displayName": "Business Central Developer's Toolset",
   "description": "Manage your Business Central development environment. Containers, backups, workspaces and more.",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "publisher": "dam-pav",
   "icon": "assets/bc-dev-toolset.logo.png",
   "license": "MIT",

--- a/vscode-extension/test/backup-mgt.test.js
+++ b/vscode-extension/test/backup-mgt.test.js
@@ -82,6 +82,24 @@ test('passes tenant IDs to BcContainerHelper so a stopped service can be restore
   });
 });
 
+test('uses the direct backup-file restore path for a stopped single-tenant service', () => {
+  const script = [
+    `. ${quotePowerShell(backupMgtPath)}`,
+    "$entries = @([pscustomobject]@{ DatabaseName='CRONUS'; DatabaseRole='database'; HelperFileName='database.bak' })",
+    "Get-BcContainerSqlBackupRestoreParameters -containerName 'OTPtest' -bakFolder 'C:\\restore' -backupEntries $entries | ConvertTo-Json -Compress"
+  ].join('; ');
+  const result = spawnSync('pwsh', ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', script], {
+    encoding: 'utf8'
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    bakFile: 'C:\\restore\\database.bak',
+    containerName: 'OTPtest',
+    databaseName: 'CRONUS'
+  });
+});
+
 test('uses tenant IDs for service backup filenames while retaining source database names', () => {
   const script = [
     `. ${quotePowerShell(backupMgtPath)}`,


### PR DESCRIPTION
- When backup set contains a single "database" entry, return bakFile + databaseName so BcContainerHelper avoids unneeded Set-NavServerInstance -Stop.
- Add Restore-BcContainerSqlBackupEntries to handle in-container stop/start and invoke Restore-DatabasesInBcContainer.
- Update TestMgt to call the new restore helper.
- Add unit test for the direct backup-file restore path.
- Minor README clarifications and example/path fixes.