### PR TITLE
feat(workspace): add explicit multitenant container mode with backup-based resolution and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ Each `configurations` entry can contain:
 
 - `name`: Distinctive name of the configuration. Mandatory. Entries with an empty name or the name `sample` are ignored.
 - `serverType`: Accepted values are `Container`, `Cloud`, or `OnPrem`. Mandatory.
+- `multitenant`: Explicit container mode passed to `New-BcContainer` by the Create container operation. When omitted, creation infers the mode from a compatible backup set. If neither the setting nor the backup determines the mode, the parameter is omitted and BcContainerHelper decides. An explicit value has priority; creation aborts with an explanation if it conflicts with the detected `*.app.bak` or `*.database.bak` backup type. Valid only for `Container`.
 - `targetType`: Accepted values are `Dev`, `Test`, `Production`.
 - `autoUpdateLaunchJson`: Optional override controlling whether this entry is included when launch.json files are updated, both manually and after container creation. It applies to all `serverType` values. When omitted, the effective value is `true` if `targetType` is `Dev`, and `false` otherwise.
 - `server`: Valid for `OnPrem`.

--- a/common/WorkspaceMgt.ps1
+++ b/common/WorkspaceMgt.ps1
@@ -750,6 +750,58 @@ function Test-AutoRestoreBackup {
     return $true
 }
 
+function Test-ConfigurationMultitenant {
+    Param (
+        [Parameter(Mandatory=$true)]
+        [PSObject] $configuration
+    )
+
+    if ($configuration.PSObject.Properties['multitenant']) {
+        return $configuration.multitenant -eq $true
+    }
+
+    return $null
+}
+
+function Resolve-ContainerMultitenantMode {
+    Param (
+        [Parameter(Mandatory=$true)]
+        [PSObject] $configuration,
+        [Parameter(Mandatory=$false)]
+        [AllowEmptyCollection()]
+        [array] $backupEntries = @()
+    )
+
+    $configuredMode = Test-ConfigurationMultitenant -configuration $configuration
+    $hasExplicitMode = $null -ne $configuration.PSObject.Properties['multitenant']
+    $hasApplicationBackup = @($backupEntries | Where-Object { $_.DatabaseRole -eq 'app' }).Count -gt 0
+    $hasSingleDatabaseBackup = @($backupEntries | Where-Object { $_.DatabaseRole -eq 'database' }).Count -gt 0
+
+    if ($hasApplicationBackup -and $hasSingleDatabaseBackup) {
+        throw "Cannot create container '$($configuration.container)': SQL backup folder contains both multitenant application (*.app.bak) and single-tenant database (*.database.bak) backups. Keep only one compatible backup set."
+    }
+
+    if ($hasApplicationBackup) {
+        if ($hasExplicitMode -and -not $configuredMode) {
+            throw "Cannot create container '$($configuration.container)': configuration '$($configuration.name)' explicitly sets multitenant to false, but sqlBackupPath contains a multitenant application (*.app.bak) backup. Set multitenant to true, remove the setting to infer it from the backup, or use a single-tenant (*.database.bak) backup."
+        }
+        return $true
+    }
+
+    if ($hasSingleDatabaseBackup) {
+        if ($hasExplicitMode -and $configuredMode) {
+            throw "Cannot create container '$($configuration.container)': configuration '$($configuration.name)' explicitly sets multitenant to true, but sqlBackupPath contains a single-tenant database (*.database.bak) backup. Set multitenant to false, remove the setting to infer it from the backup, or use a multitenant (*.app.bak) backup set."
+        }
+        return $false
+    }
+
+    if ($hasExplicitMode) {
+        return $configuredMode
+    }
+
+    return $null
+}
+
 function Write-LaunchJSON {
     Param (
         [Parameter(Mandatory=$true)]
@@ -2098,6 +2150,11 @@ function New-DockerContainer {
             shortcuts = $settingsJSON.shortcuts
             }
 
+        $resolvedMultitenantMode = Resolve-ContainerMultitenantMode -configuration $configuration
+        if ($null -ne $resolvedMultitenantMode) {
+            $Parameters.multitenant = $resolvedMultitenantMode
+        }
+
         $updateHosts = -not ($configuration.PSObject.Properties['updateHosts'] -and ([string]$configuration.updateHosts).Trim().ToLowerInvariant() -eq 'false')
         if ($updateHosts) {
             if (Repair-HostsFilePermissions) {
@@ -2149,6 +2206,14 @@ function New-DockerContainer {
                 $backupEntries = @(Get-SqlBackupSetEntries -backupRootPath $backupRootPath)
                 $appBackupEntries = @($backupEntries | Where-Object { $_.DatabaseRole -eq 'app' })
                 $databaseBackupEntries = @($backupEntries | Where-Object { $_.DatabaseRole -eq 'database' })
+                $resolvedMultitenantMode = Resolve-ContainerMultitenantMode `
+                    -configuration $configuration `
+                    -backupEntries $backupEntries
+                if ($null -ne $resolvedMultitenantMode) {
+                    $Parameters.multitenant = $resolvedMultitenantMode
+                } else {
+                    $Parameters.Remove('multitenant')
+                }
                 if ($appBackupEntries.Count -gt 0) {
                     $Parameters.bakFolder = Copy-SqlBackupSetToSharedFolder `
                         -containerName $configuration.container `
@@ -2161,7 +2226,6 @@ function New-DockerContainer {
                         -containerName $configuration.container `
                         -backupRootPath $backupRootPath `
                         -sharedFolderName "NewContainer"
-                    $Parameters.multitenant = $false
 
                     Write-Host "New single-tenant container will be initialized from SQL backup set '$backupRootPath'." -ForegroundColor Green
                 } elseif ($backupEntries.Count -gt 0) {

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -193,6 +193,7 @@ Each workspace `configuration` entry can contain:
 - `server`: Business Central server name for `OnPrem`.
 - `serverInstance`: Business Central server instance for `OnPrem`.
 - `container`: Docker container name for `Container`. Create-container processing only includes Container configurations with a non-empty `container` value, and duplicate `container` values abort the operation.
+- `multitenant`: Explicit container mode passed to `New-BcContainer` by the Create container operation. When omitted, creation infers the mode from a compatible backup set. If neither the setting nor the backup determines the mode, the parameter is omitted and BcContainerHelper decides. An explicit value has priority; creation aborts with an explanation if it conflicts with the detected `*.app.bak` or `*.database.bak` backup type. Valid only for `Container`.
 - `port`: Service port for `OnPrem`.
 - `environmentType`: Environment kind. Valid values: `Sandbox`, `OnPrem`.
 - `environmentName`: Business Central environment name for `Cloud`.

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -274,6 +274,10 @@
                           ],
                           "description": "Business Central environment type."
                         },
+                        "multitenant": {
+                          "type": "boolean",
+                          "description": "Explicit multitenant mode passed to New-BcContainer. When omitted, Create Docker container infers the mode from a compatible backup set; if the backup does not determine the mode, the parameter is omitted and BcContainerHelper decides. Creation aborts when an explicit value conflicts with the backup type."
+                        },
                         "includeTestToolkit": {
                           "type": [
                             "string",
@@ -524,6 +528,11 @@
                         "includeTestToolkit": {
                           "not": {},
                           "errorMessage": "Field \"includeTestToolkit\" is not valid when \"serverType\" is not \"Container\".",
+                          "doNotSuggest": true
+                        },
+                        "multitenant": {
+                          "not": {},
+                          "errorMessage": "Field \"multitenant\" is not valid when \"serverType\" is not \"Container\".",
                           "doNotSuggest": true
                         },
                         "bcUser": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "bc-dev-toolset",
   "displayName": "Business Central Developer's Toolset",
   "description": "Manage your Business Central development environment. Containers, backups, workspaces and more.",
-  "version": "1.4.8",
+  "version": "1.4.10",
   "publisher": "dam-pav",
   "icon": "assets/bc-dev-toolset.logo.png",
   "license": "MIT",

--- a/vscode-extension/schemas/bcdevtoolset-settings.schema.json
+++ b/vscode-extension/schemas/bcdevtoolset-settings.schema.json
@@ -184,6 +184,10 @@
                 ],
                 "description": "Business Central environment type."
               },
+              "multitenant": {
+                "type": "boolean",
+                "description": "Explicit multitenant mode passed to New-BcContainer. When omitted, Create Docker container infers the mode from a compatible backup set; if the backup does not determine the mode, the parameter is omitted and BcContainerHelper decides. Creation aborts when an explicit value conflicts with the backup type."
+              },
               "includeTestToolkit": {
                 "type": [
                   "string",
@@ -431,6 +435,11 @@
               "includeTestToolkit": {
                 "not": {},
                 "errorMessage": "Field \"includeTestToolkit\" is not valid when \"serverType\" is not \"Container\".",
+                "doNotSuggest": true
+              },
+              "multitenant": {
+                "not": {},
+                "errorMessage": "Field \"multitenant\" is not valid when \"serverType\" is not \"Container\".",
                 "doNotSuggest": true
               },
               "bcUser": {

--- a/vscode-extension/test/workspace-mgt.test.js
+++ b/vscode-extension/test/workspace-mgt.test.js
@@ -228,6 +228,76 @@ test('automatic backup restore requires a boolean Container configuration flag w
   const manualOperation = fs.readFileSync(path.join(repositoryRoot, 'operations', 'RestoreBcContainerDatabases.ps1'), 'utf8');
   assert.doesNotMatch(manualOperation, /autoRestoreBackup/);
 });
+
+test('container creation supports an optional explicit multitenant mode', () => {
+  const script = `
+    . '${workspaceMgtPath.replaceAll("'", "''")}'
+    $implicit = Test-ConfigurationMultitenant -configuration ([PSCustomObject]@{ serverType = 'Container' })
+    if ($null -ne $implicit) { exit 2 }
+    if (-not (Test-ConfigurationMultitenant -configuration ([PSCustomObject]@{ serverType = 'Container'; multitenant = $true }))) { exit 3 }
+    if (Test-ConfigurationMultitenant -configuration ([PSCustomObject]@{ serverType = 'Container'; multitenant = $false })) { exit 4 }
+  `;
+  runPowerShell(script);
+
+  const schema = JSON.parse(fs.readFileSync(path.join(repositoryRoot, 'vscode-extension', 'schemas', 'bcdevtoolset-settings.schema.json'), 'utf8'));
+  const containerRule = schema.definitions.configuration.allOf.find((rule) => rule.if?.properties?.serverType?.const === 'Container');
+  assert.deepEqual(containerRule.then.properties.multitenant, {
+    type: 'boolean',
+    description: 'Explicit multitenant mode passed to New-BcContainer. When omitted, Create Docker container infers the mode from a compatible backup set; if the backup does not determine the mode, the parameter is omitted and BcContainerHelper decides. Creation aborts when an explicit value conflicts with the backup type.'
+  });
+
+  const nonContainerRule = schema.definitions.configuration.allOf.find((rule) =>
+    rule.if?.not?.properties?.serverType?.const === 'Container' && rule.then?.properties?.multitenant);
+  assert.ok(nonContainerRule);
+
+  const source = fs.readFileSync(workspaceMgtPath, 'utf8');
+  const containerCreationFunction = source.match(/function New-DockerContainer[\s\S]*?\n}/)?.[0] ?? '';
+  assert.match(containerCreationFunction, /\$resolvedMultitenantMode = Resolve-ContainerMultitenantMode -configuration \$configuration[\s\S]*?\$Parameters\.multitenant = \$resolvedMultitenantMode/);
+  assert.doesNotMatch(containerCreationFunction, /multitenant = \(Test-ConfigurationMultitenant/);
+  assert.match(containerCreationFunction, /\$resolvedMultitenantMode = Resolve-ContainerMultitenantMode[\s\S]*?-backupEntries \$backupEntries[\s\S]*?\$Parameters\.multitenant = \$resolvedMultitenantMode/);
+  const settingsBuilder = source.match(/function Build-Settings[\s\S]*?\n}/)?.[0] ?? '';
+  assert.doesNotMatch(settingsBuilder, /-Name multitenant/);
+
+  const extensionSource = fs.readFileSync(path.join(repositoryRoot, 'vscode-extension', 'extension.js'), 'utf8');
+  const defaultLocalConfiguration = extensionSource.match(/function getDefaultLocalConfiguration\(\)[\s\S]*?\n}/)?.[0] ?? '';
+  assert.doesNotMatch(defaultLocalConfiguration, /multitenant:/);
+  assert.equal(Object.hasOwn(schema.properties.configurations.default[0], 'multitenant'), false);
+});
+
+test('explicit multitenant mode wins and conflicting backup types abort creation', () => {
+  const script = `
+    . '${workspaceMgtPath.replaceAll("'", "''")}'
+    $appBackup = @([PSCustomObject]@{ DatabaseRole = 'app' })
+    $databaseBackup = @([PSCustomObject]@{ DatabaseRole = 'database' })
+    $implicit = [PSCustomObject]@{ name = 'Local'; container = 'test' }
+    $undecided = Resolve-ContainerMultitenantMode -configuration $implicit -backupEntries @()
+    if ($null -ne $undecided) { exit 2 }
+    if (-not (Resolve-ContainerMultitenantMode -configuration $implicit -backupEntries $appBackup)) { exit 2 }
+    if (Resolve-ContainerMultitenantMode -configuration $implicit -backupEntries $databaseBackup) { exit 3 }
+
+    $explicitMulti = [PSCustomObject]@{ name = 'Local'; container = 'test'; multitenant = $true }
+    $explicitSingle = [PSCustomObject]@{ name = 'Local'; container = 'test'; multitenant = $false }
+    if (-not (Resolve-ContainerMultitenantMode -configuration $explicitMulti -backupEntries @())) { exit 4 }
+    if (Resolve-ContainerMultitenantMode -configuration $explicitSingle -backupEntries @()) { exit 5 }
+
+    $explicitMultiConflict = ''
+    try { Resolve-ContainerMultitenantMode -configuration $explicitMulti -backupEntries $databaseBackup | Out-Null }
+    catch { $explicitMultiConflict = $_.Exception.Message }
+    if ($explicitMultiConflict -notmatch 'explicitly sets multitenant to true') { exit 6 }
+
+    $explicitSingleConflict = ''
+    try { Resolve-ContainerMultitenantMode -configuration $explicitSingle -backupEntries $appBackup | Out-Null }
+    catch { $explicitSingleConflict = $_.Exception.Message }
+    if ($explicitSingleConflict -notmatch 'explicitly sets multitenant to false') { exit 7 }
+
+    $mixedBackupConflict = ''
+    try { Resolve-ContainerMultitenantMode -configuration $implicit -backupEntries @($appBackup + $databaseBackup) | Out-Null }
+    catch { $mixedBackupConflict = $_.Exception.Message }
+    if ($mixedBackupConflict -notmatch 'both multitenant application') { exit 8 }
+  `;
+  runPowerShell(script);
+});
+
 test('Add Test Toolkit operation selects one configured container and aborts invalid selections', () => {
   const operations = JSON.parse(fs.readFileSync(path.join(repositoryRoot, 'operations', 'operations.json'), 'utf8'));
   const operation = operations.find(({ id }) => id === 'addTestToolkitToBcContainer');

--- a/vscode-extension/test/workspace-mgt.test.js
+++ b/vscode-extension/test/workspace-mgt.test.js
@@ -258,7 +258,8 @@ test('container creation supports an optional explicit multitenant mode', () => 
   const settingsBuilder = source.match(/function Build-Settings[\s\S]*?\n}/)?.[0] ?? '';
   assert.doesNotMatch(settingsBuilder, /-Name multitenant/);
 
-  const extensionSource = fs.readFileSync(path.join(repositoryRoot, 'vscode-extension', 'extension.js'), 'utf8');
+  const extensionSource = fs.readFileSync( // nosemgrep -- fixed segments resolve beneath the authorized repository root
+    path.join(repositoryRoot, 'vscode-extension', 'extension.js'), 'utf8');
   const defaultLocalConfiguration = extensionSource.match(/function getDefaultLocalConfiguration\(\)[\s\S]*?\n}/)?.[0] ?? '';
   assert.doesNotMatch(defaultLocalConfiguration, /multitenant:/);
   assert.equal(Object.hasOwn(schema.properties.configurations.default[0], 'multitenant'), false);


### PR DESCRIPTION
Introduce Test-ConfigurationMultitenant and Resolve-ContainerMultitenantMode to resolve an explicit multitenant setting or infer it from SQL backup sets, aborting on conflicting backup types. Pass resolved mode to New-BcContainer parameters, remove hardcoded assignments, update JSON schema, package and README docs to expose the "multitenant" configuration, and add unit tests covering explicit/implicit modes and conflict cases.